### PR TITLE
Fix exception when loading gloweffect asset

### DIFF
--- a/Example-tvOS/ParallaxViewExample/CollectionViewCell.swift
+++ b/Example-tvOS/ParallaxViewExample/CollectionViewCell.swift
@@ -21,8 +21,8 @@ class CollectionViewCell: ParallaxCollectionViewCell {
 
         parallaxEffectOptions.glowAlpha = 0.4
         parallaxEffectOptions.shadowPanDeviation = 10
-        parallaxEffectOptions.parallaxMotionEffect.viewingAngleX = CGFloat(M_PI_4/30)
-        parallaxEffectOptions.parallaxMotionEffect.viewingAngleY = CGFloat(M_PI_4/30)
+        parallaxEffectOptions.parallaxMotionEffect.viewingAngleX = CGFloat(Double.pi/4/30)
+        parallaxEffectOptions.parallaxMotionEffect.viewingAngleY = CGFloat(Double.pi/4/30)
         parallaxEffectOptions.parallaxMotionEffect.panValue = CGFloat(5)
 
         // You can customise parallax view standard behaviours using parallaxViewActions property.

--- a/Resources/Assets.xcassets/gloweffect.imageset/Contents.json
+++ b/Resources/Assets.xcassets/gloweffect.imageset/Contents.json
@@ -1,17 +1,9 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
+      "idiom" : "tv",
       "filename" : "gloweffect.png",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "scale" : "1x"
     }
   ],
   "info" : {


### PR DESCRIPTION
Defining the gloweffect asset as universal crashes on Xcode 9. This PR defines gloweffect asset as a tvOS asset. 